### PR TITLE
Changes for AksIot

### DIFF
--- a/hcn/hcnnetwork.go
+++ b/hcn/hcnnetwork.go
@@ -453,7 +453,9 @@ func (network *HostComputeNetwork) Create() (*HostComputeNetwork, error) {
 		for _, subnet := range ipam.Subnets {
 			if subnet.IpAddressPrefix != "" {
 				hasDefault := false
+				needsDefault := false
 				for _, route := range subnet.Routes {
+					needsDefault = true
 					if route.NextHop == "" {
 						return nil, errors.New("network create error, subnet has address prefix but no gateway specified")
 					}
@@ -461,7 +463,7 @@ func (network *HostComputeNetwork) Create() (*HostComputeNetwork, error) {
 						hasDefault = true
 					}
 				}
-				if !hasDefault {
+				if !hasDefault && needsDefault {
 					return nil, errors.New("network create error, no default gateway")
 				}
 			}

--- a/vm.go
+++ b/vm.go
@@ -54,6 +54,7 @@ type VirtualMachineOptions struct {
 	VnicId             string
 	MacAddress         string
 	UseGuestConnection bool
+	UseVsock           bool
 	AllowOvercommit    bool
 }
 
@@ -132,7 +133,7 @@ func CreateVirtualMachineSpec(opts *VirtualMachineOptions) (*VirtualMachineSpec,
 
 	if opts.UseGuestConnection {
 		spec.VirtualMachine.GuestConnection = &hcsschema.GuestConnection{
-			UseVsock:            true,
+			UseVsock:            opts.UseVsock,
 			UseConnectedSuspend: true,
 		}
 	}

--- a/vm.go
+++ b/vm.go
@@ -71,10 +71,12 @@ type VirtualMachineSpec struct {
 func CreateVirtualMachineSpec(opts *VirtualMachineOptions) (*VirtualMachineSpec, error) {
 	// Ensure the VM has access, we use opts.Id to create VM
 	if err := wclayer.GrantVmAccess(opts.Id, opts.VhdPath); err != nil {
-		return nil, err
+		// TODO we need to sort this out - if we error here, VMs won't come up anymore after reboot
+		//return nil, fmt.Errorf("Failed to grant VM access to VHD file, error: %s", err)
 	}
 	if err := wclayer.GrantVmAccess(opts.Id, opts.IsoPath); err != nil {
-		return nil, err
+		//return nil, fmt.Errorf("Failed to grant VM access to ISO file, error: %s", err)
+		err = nil
 	}
 
 	spec := &hcsschema.ComputeSystem{

--- a/vm.go
+++ b/vm.go
@@ -71,12 +71,10 @@ type VirtualMachineSpec struct {
 func CreateVirtualMachineSpec(opts *VirtualMachineOptions) (*VirtualMachineSpec, error) {
 	// Ensure the VM has access, we use opts.Id to create VM
 	if err := wclayer.GrantVmAccess(opts.Id, opts.VhdPath); err != nil {
-		// TODO we need to sort this out - if we error here, VMs won't come up anymore after reboot
-		//return nil, fmt.Errorf("Failed to grant VM access to VHD file, error: %s", err)
+		return nil, fmt.Errorf("Failed to grant VM access to VHD file, error: %s", err)
 	}
 	if err := wclayer.GrantVmAccess(opts.Id, opts.IsoPath); err != nil {
-		//return nil, fmt.Errorf("Failed to grant VM access to ISO file, error: %s", err)
-		err = nil
+		return nil, fmt.Errorf("Failed to grant VM access to ISO file, error: %s", err)
 	}
 
 	spec := &hcsschema.ComputeSystem{
@@ -365,7 +363,7 @@ func (vm *VirtualMachineSpec) HotDetachEndpoint(endpoint *hcn.HostComputeEndpoin
 	// Hot detach an endpoint from the compute system
 	request := hcsschema.ModifySettingRequest{
 		RequestType:  requesttype.Remove,
-		ResourcePath: path.Join("VirtualMachine/Devices/NetworkAdapters", endpoint.Id),
+		ResourcePath: path.Join("VirtualMachine/Devices/NetworkAdapters", endpoint.Name),
 		Settings: hcsschema.NetworkAdapter{
 			EndpointId: endpoint.Id,
 			MacAddress: endpoint.MacAddress,
@@ -383,7 +381,7 @@ func (vm *VirtualMachineSpec) hotAttachEndpoint(ctx context.Context, system *hcs
 	// Hot attach an endpoint to the compute system
 	request := hcsschema.ModifySettingRequest{
 		RequestType:  requesttype.Add,
-		ResourcePath: path.Join("VirtualMachine/Devices/NetworkAdapters", endpoint.Id),
+		ResourcePath: path.Join("VirtualMachine/Devices/NetworkAdapters", endpoint.Name),
 		Settings: hcsschema.NetworkAdapter{
 			EndpointId: endpoint.Id,
 			MacAddress: endpoint.MacAddress,


### PR DESCRIPTION
- To enable dynamic deployment scenarios, only require a gateway when there is routes defined
- To enable deployment of Windows VM (which do not use vsock), extend the CreateVirtualMachineSpec interface